### PR TITLE
microrl: add configuration option for prompt coloring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Develop
 
 1.  Move `inline` keyword setting to config file
+2.  Add configuration parameter for prompt coloring
 
 
 ## v2.4.2

--- a/src/include/microrl/microrl_config.h
+++ b/src/include/microrl/microrl_config.h
@@ -74,6 +74,13 @@ extern "C" {
 #define MICRORL_CFG_PROMPT_STRING             "> "
 #endif
 
+/**
+ * \brief           Enable ANSI color escape sequences in prompt
+ */
+#ifndef MICRORL_CFG_USE_PROMPT_COLOR
+#define MICRORL_CFG_USE_PROMPT_COLOR          1
+#endif
+
 #define MICRORL_COLOR_RED                     "\033[31m"
 #define MICRORL_COLOR_GREEN                   "\033[32m"
 #define MICRORL_COLOR_YELLOW                  "\033[33m"

--- a/src/microrl/microrl.c
+++ b/src/microrl/microrl.c
@@ -244,9 +244,13 @@ MICRORL_CFG_STATIC_INLINE void prv_cmdline_buf_reset(microrl_t* mrl) {
  * \param[in]       mrl: \ref microrl_t working instance
  */
 MICRORL_CFG_STATIC_INLINE void prv_terminal_print_prompt(microrl_t* mrl) {
+#if MICRORL_CFG_USE_PROMPT_COLOR
     mrl->out_fn(mrl, MICRORL_CFG_PROMPT_COLOR);
     mrl->out_fn(mrl, mrl->prompt_ptr);
     mrl->out_fn(mrl, MICRORL_COLOR_DEFAULT);
+#else
+    mrl->out_fn(mrl, mrl->prompt_ptr);
+#endif
 }
 
 /**


### PR DESCRIPTION
Add a configuration option for disabling output of ANSI color escape codes. This option is defaulted off to match existing behavior.