### PR TITLE
Fix prompt size to skip ansii color chars

### DIFF
--- a/src/include/microrl/microrl.h
+++ b/src/include/microrl/microrl.h
@@ -159,6 +159,7 @@ typedef struct microrl {
 #endif /* MICRORL_CFG_USE_CTRL_C || __DOXYGEN__ */
 
     char* prompt_ptr;                           /*!< Pointer to prompt string */
+    size_t prompt_size;                          /*!< Size of prompt string */
     char cmdline_str[MICRORL_CFG_CMDLINE_LEN + 1];  /*!< Command line input buffer with NULL character */
     size_t cmdlen;                              /*!< Command length in command line buffer */
     size_t cursor;                              /*!< Command line buffer position pointer */


### PR DESCRIPTION
Hello,

First, thank you for your work on this library.

I use microrl with a prompt that has multiple colors like this:

```c
#define MICRORL_CFG_PROMPT_STRING             MICRORL_COLOR_GREEN "user@host" MICRORL_COLOR_DEFAULT ":" MICRORL_COLOR_BLUE "~" MICRORL_COLOR_DEFAULT "$ "
```

When I use the command history, the cursor is not positioned correctly due to the strlen of the prompt. Like this:

```bash
user@host:~$            help
```
So this PR fixes this by computing the prompt size excluding ANSI codes.

Thanks

