### PR TITLE
Fix auto complete and clear terminal

### DIFF
--- a/src/include/microrl/microrl.h
+++ b/src/include/microrl/microrl.h
@@ -201,7 +201,7 @@ microrlr_t  microrl_processing_input(microrl_t* mrl, const void* data_ptr, size_
 
 uint32_t    microrl_get_version(void);
 
-microrlr_t  microrl_clear_terminal(microrl_t* mrl);
+microrlr_t  microrl_clear_terminal(microrl_t* mrl, uint8_t reset);
 
 /**
  * \}

--- a/src/microrl/microrl.c
+++ b/src/microrl/microrl.c
@@ -1061,7 +1061,7 @@ static microrlr_t prv_control_char_process(microrl_t* mrl, char ch) {
             break;
         }
         case MICRORL_ESC_ANSI_FF: { /* ^L */
-            microrl_clear_terminal(mrl);
+            microrl_clear_terminal(mrl, 0);
             break;
         }
         default:
@@ -1174,17 +1174,23 @@ uint32_t microrl_get_version(void) {
 /**
  * \brief           Clear terminal screen and print prompt
  * \param[in,out]   mrl: \ref microrl_t working instance
+ * \param[in]       reset: reset the current command line buffer
  * \return          \ref microrlOK on success, member of \ref microrlr_t enumeration otherwise
  */
-microrlr_t  microrl_clear_terminal(microrl_t* mrl){
+microrlr_t  microrl_clear_terminal(microrl_t* mrl, uint8_t reset){
     if (mrl == NULL) {
         return microrlERRPAR;
     }
-
+    
+    mrl->out_fn(mrl, "\033[3J");        /* Clear entire screen + scrollback */
     mrl->out_fn(mrl, "\033[2J");        /* Clear screen */
-    mrl->out_fn(mrl, "\033[H");         /* Move cursor to home position */
-    prv_terminal_print_prompt(mrl);
-    prv_terminal_print_line(mrl, 0, 0);
+    mrl->out_fn(mrl, "\033[1;1H");      /* Move cursor to position 1,1 */
+    mrl->out_fn(mrl, "\033[0m");        /* Reset all attributes */
+    if (!reset) {
+        // If reset is not requested, reprint current command line: used with Ctrl+L
+        prv_terminal_print_prompt(mrl);
+        prv_terminal_print_line(mrl, 0, 0);
+    }
 
     return microrlOK;
 }

--- a/src/microrl/microrl.c
+++ b/src/microrl/microrl.c
@@ -750,6 +750,12 @@ static microrlr_t prv_complete_get_input(microrl_t* mrl) {
 
     cmplt_tkn_arr = mrl->get_completion_fn(mrl, tkn_cnt, tkn_str_arr);
     if (cmplt_tkn_arr[0] == NULL) {
+        /* Restore whitespaces replaced with '0' when command line buffer was split */
+        if (tkn_cnt != 0) {
+            for (size_t i = 0; i < (size_t)(tkn_cnt - 1); ++i) {
+                memset((char*)tkn_str_arr[i] + strlen(tkn_str_arr[i]), ' ', 1);
+            }
+        }
         return microrlERRCPLT;
     }
 


### PR DESCRIPTION
Hello,

I found a bug when using the auto-complete feature:
If no result is found, the auto-complete returns directly:
```c
    if (cmplt_tkn_arr[0] == NULL) {
        return microrlERRCPLT;
    }
```

So after the return, the command no longer works because the command string is still separated by 0.

I added the whitespace conversion again before the return.
Now, if no result is found, the command is not edited.

I also fixed the clear function with an argument to specify if we want to clear the current command.

Thanks

commit:
* fix: auto-complete restore whitespaces on error
* fix: terminal clear with a reset argument