### PR TITLE
Fix overflow if history size is integer multiple of entries

### DIFF
--- a/src/include/microrl/microrl_config.h
+++ b/src/include/microrl/microrl_config.h
@@ -264,7 +264,7 @@ extern "C" {
 
 #define MICRORL_VERSION_MAJOR                 2
 #define MICRORL_VERSION_MINOR                 6
-#define MICRORL_VERSION_PATCH                 0
+#define MICRORL_VERSION_PATCH                 1
 
 #ifdef __cplusplus
 }

--- a/src/include/microrl/microrl_config.h
+++ b/src/include/microrl/microrl_config.h
@@ -98,6 +98,13 @@ extern "C" {
 #endif
 
 /**
+ * \brief           Disable the tokenizer to get the full command in the first slot of the argv array
+ */
+#ifndef MICRORL_CFG_DISABLE_TOKENIZER
+#define MICRORL_CFG_DISABLE_TOKENIZER 0
+#endif
+
+/**
  * \brief           Enable it, if you want to use completion functional, also set completion callback in you code.
  *                  Completion functional calls 'copmletion' callback if user press 'TAB'.
  */

--- a/src/microrl/microrl.c
+++ b/src/microrl/microrl.c
@@ -667,7 +667,15 @@ static microrlr_t prv_handle_newline(microrl_t* mrl) {
     }
 #endif /* MICRORL_CFG_USE_ECHO_OFF */
 
+#if MICRORL_CFG_DISABLE_TOKENIZER
+    tkn_str_arr[0] = mrl->cmdline_str;
+    tkn_cnt = 1;
+    status = microrlOK;
+    (void)prv_cmdline_buf_split;  /*avoid declared but never referenced warning */
+#else
     status = prv_cmdline_buf_split(mrl, tkn_str_arr, &tkn_cnt, mrl->cmdlen);
+#endif /* MICRORL_CFG_DISABLE_TOKENIZER */
+
     if (status == microrlOK) {
 #if MICRORL_CFG_USE_COMMAND_HOOKS
         int exec_status = 0;

--- a/src/microrl/microrl.c
+++ b/src/microrl/microrl.c
@@ -396,14 +396,13 @@ static void prv_terminal_print_line(microrl_t* mrl, int32_t pos, uint8_t reset) 
  * \param[in,out]   idx_ptr: Pointer to the current record
  */
 MICRORL_CFG_STATIC_INLINE void prv_hist_next_record(microrl_hist_rbuf_t* rbuf_ptr, size_t* idx_ptr) {
-    while (rbuf_ptr->ring_buf[++(*idx_ptr)] != '\0') {
+    do {
+        ++(*idx_ptr);
+
         if (*idx_ptr >= MICRORL_ARRAYSIZE(rbuf_ptr->ring_buf)) {
             *idx_ptr -= MICRORL_ARRAYSIZE(rbuf_ptr->ring_buf);
-            if (rbuf_ptr->ring_buf[*idx_ptr] == '\0') {
-                break;
-            }
         }
-    }
+    } while (rbuf_ptr->ring_buf[*idx_ptr] != '\0');
 }
 
 /**
@@ -480,7 +479,10 @@ static size_t prv_hist_restore_line(microrl_hist_rbuf_t* rbuf_ptr, char* line_st
         prv_hist_next_record(rbuf_ptr, &idx);
     }
 
-    ++idx;                                      /* Move position from `\0` marker */
+    ++idx;                                      /* Move position from `\0` marker and take care of wrap-around*/
+    if (idx >= MICRORL_ARRAYSIZE(rbuf_ptr->ring_buf)) {
+        idx -= MICRORL_ARRAYSIZE(rbuf_ptr->ring_buf);
+    }
 
     size_t rec_len = 0;
     size_t k = idx;


### PR DESCRIPTION
Thanks for the great library! I'm really happy with it. However, I came across an edge case which led to a crash in my system.

The issue can be reproduced with the following use case:

- Default history size: MICRORL_CFG_RING_HISTORY_LEN          64
- Commands send to history: ```Display.Backlight(0)```, ```Display.Backlight(1)```, ```Display.Backlight(2)```, ```Display.Backlight(3)```.
- Sending the up-key to select the last history entry subsequently crashed my program 

Analysis:
- Contents of the commands don't matter, the error is seemingly triggered by the length of the commands leading to the trailing ```\0``` being the last byte of the buffer.
- There is an out-of-bounds situation on this variable
  ```
  ++idx;                                      /* Move position from `\0` marker */
  ```
  (see diff)
- Crash happened here:
  ```
  size_t part0 = MICRORL_ARRAYSIZE(rbuf_ptr->ring_buf) - idx;
  memcpy(line_str, rbuf_ptr->ring_buf + idx, part0);
  ```
  with a negative ```part0``` leading to memory overwrites.

The proposed code changes fix the error but additional consequences are not entirely clear. Feedback always welcome.

Cheers!
Felix

